### PR TITLE
chore: adopt tx3-sdk 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,7 +1216,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -2286,7 +2286,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2323,7 +2323,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3475,9 +3475,9 @@ dependencies = [
 
 [[package]]
 name = "tx3-sdk"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16120896b5d73621383f4980b3047769de90aea90fe26f500152d61d2287ddaa"
+checksum = "fcad9b73ab830b85345392c2cf8c8ffeafae7945c2c4565047c559d3d3ea08d2"
 dependencies = [
  "base64 0.22.1",
  "bech32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["cardano", "blockchain", "wallet"]
 categories = ["command-line-utilities", "blockchain", "cardano", "wallet"]
 
 [dependencies]
-tx3-sdk = "0.13.0"
+tx3-sdk = "0.14.0"
 # tx3-sdk = { git = "https://github.com/tx3-lang/rust-sdk.git" }
 # tx3-sdk = { path = "../../tx3-lang/rust-sdk/sdk" }
 


### PR DESCRIPTION
## What

Bumps the `tx3-sdk` dependency `0.13.0` → `0.14.0` (just published), so `cshell` — and `trix invoke`, which spawns it — can pass an argument of an aggregate type (record, `List`, `Map`, `Tuple`). The SDK serializes it into the TRP `TaggedArg` wire form.

## No code change

The encoding happens entirely inside the SDK's `Invocation::into_resolve_request`, which `cshell` already calls on the invoke/resolve path (`load_args` → `set_args` → `into_resolve_request`). The breaking `ParamType::Record` reshape in 0.14.0 doesn't touch `cshell`, which only matches the scalar `ParamType` kinds.

## Verification

- `cargo build` / `cargo test` green (6 passed) against the published `tx3-sdk 0.14.0`.
- Diff is the pin + lockfile only; no `cshell` version bump (that's a separate release step).

> Note: `cargo clippy` reports 11 warnings, but these are **pre-existing on `main`** (unrelated to this dep bump) — left out of scope to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency to latest version for improved compatibility and performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->