### PR TITLE
chore: clear clippy lints for green CI

### DIFF
--- a/src/explorer/widgets/tabs/accounts.rs
+++ b/src/explorer/widgets/tabs/accounts.rs
@@ -21,17 +21,13 @@ pub struct AccountsTabState {
 impl AccountsTabState {
     pub fn handle_key(&mut self, key: &KeyEvent) {
         match (key.code, key.modifiers) {
-            (KeyCode::Char('l') | KeyCode::Right, _) => {
-                if self.list_state.selected().is_some() {
-                    self.focus_on_table = true;
-                    self.table_state.select_next();
-                }
+            (KeyCode::Char('l') | KeyCode::Right, _) if self.list_state.selected().is_some() => {
+                self.focus_on_table = true;
+                self.table_state.select_next();
             }
-            (KeyCode::Char('h') | KeyCode::Left, _) => {
-                if self.focus_on_table {
-                    self.focus_on_table = false;
-                    self.table_state.select(None);
-                }
+            (KeyCode::Char('h') | KeyCode::Left, _) if self.focus_on_table => {
+                self.focus_on_table = false;
+                self.table_state.select(None);
             }
             (KeyCode::Char('j') | KeyCode::Down, _) => {
                 if self.focus_on_table {

--- a/src/explorer/widgets/tabs/transactions.rs
+++ b/src/explorer/widgets/tabs/transactions.rs
@@ -68,24 +68,20 @@ impl TransactionsTabState {
                     (KeyCode::Char('f') | KeyCode::Char('/'), _) => {
                         self.input_mode = InputMode::Editing
                     }
-                    (KeyCode::Esc, _) => {
-                        if !self.search_input.is_empty() {
-                            self.search_input.clear();
-                            self.txs = self
-                                .blocks
-                                .borrow()
-                                .iter()
-                                .flat_map(TxView::from_chain_block)
-                                .collect();
-                        }
+                    (KeyCode::Esc, _) if !self.search_input.is_empty() => {
+                        self.search_input.clear();
+                        self.txs = self
+                            .blocks
+                            .borrow()
+                            .iter()
+                            .flat_map(TxView::from_chain_block)
+                            .collect();
                     }
-                    (KeyCode::Enter, _) => {
-                        if self.table_state.selected().is_some() {
-                            self.detail_state.tree_state.close_all();
-                            self.detail_state.tree_state.select_first();
-                            self.view_mode = ViewMode::Detail;
-                            self.tx_selected = None;
-                        }
+                    (KeyCode::Enter, _) if self.table_state.selected().is_some() => {
+                        self.detail_state.tree_state.close_all();
+                        self.detail_state.tree_state.select_first();
+                        self.view_mode = ViewMode::Detail;
+                        self.tx_selected = None;
                     }
                     _ => {}
                 },

--- a/src/provider/create.rs
+++ b/src/provider/create.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use anyhow::{bail, Result};
@@ -11,12 +10,6 @@ use crate::{output::OutputFormatter, provider::types::Provider, utils::Name};
 enum NetworkKind {
     Mainnet,
     Testnet,
-}
-
-#[derive(Serialize, Deserialize)]
-struct UTxORPCParameters {
-    url: String,
-    headers: HashMap<String, String>,
 }
 
 #[derive(Parser, Clone)]

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{command, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use comfy_table::Table;
 use tracing::instrument;
 use utxorpc::{
@@ -52,7 +52,7 @@ fn cardano_tx_table(block_hash: Option<Vec<u8>>, tx: &[Tx]) -> Table {
     ]);
 
     let block_hash = block_hash
-        .map(|b| hex::encode(b))
+        .map(hex::encode)
         .map(|x| format!("{}...{}", &x[..4], &x[x.len() - 4..]))
         .unwrap_or_default();
 

--- a/src/tx/common.rs
+++ b/src/tx/common.rs
@@ -2,14 +2,10 @@ use anyhow::{bail, Context as _, Result};
 use inquire::{Confirm, MultiSelect};
 use pallas::ledger::addresses::Address;
 use serde_json::{json, Value};
-use std::{
-    collections::{BTreeMap, HashMap},
-    path::Path,
-};
+use std::path::Path;
 
 use tx3_sdk::{
-    core::ArgMap,
-    tii::{Invocation, ParamMap, ParamType},
+    tii::{Invocation, ParamType},
     trp::TxEnvelope,
 };
 
@@ -74,7 +70,7 @@ fn inquire_custom_address(param_key: &str) -> Result<Address> {
         .with_help_message("Enter a bech32 address")
         .prompt()?;
 
-    Ok(Address::from_bech32(&value).context("invalid bech32 address")?)
+    Address::from_bech32(&value).context("invalid bech32 address")
 }
 
 fn inquire_address(ctx: &crate::Context, provider: &Provider, param_key: &str) -> Result<Address> {
@@ -274,8 +270,7 @@ mod tests {
     #[test]
     fn invoke_encodes_diverse_args_into_resolve_request() {
         let tii = format!("{}/tests/fixtures/invoke.tii", env!("CARGO_MANIFEST_DIR"));
-        let mut invocation =
-            prepare_invocation(Path::new(&tii), Some("transfer"), None).unwrap();
+        let mut invocation = prepare_invocation(Path::new(&tii), Some("transfer"), None).unwrap();
 
         let args_json = r#"{
             "quantity": 2000000,


### PR DESCRIPTION
`cargo clippy -- -D warnings` (the CI `lint` gate) was failing on pre-existing warnings, so `main` is currently red. This clears them — a preliminary step for the next cshell release.

Fixes (no behavior change):
- drop unused imports (`search`, `tx/common`) and the never-constructed `UTxORPCParameters` struct (+ its orphaned serde import);
- collapse inner `if`s into match guards in the explorer key handlers — the catch-all arm is a no-op `_ => {}`, so behavior is identical;
- redundant closure → method reference; drop a needless `Ok(..?)`.

## Verification

- `cargo clippy -- -D warnings` clean (also `--all-targets`);
- `cargo test` green (7).

> Context: these fixes were authored alongside the invoke-arg test (#54) but landed on the branch just after #54 merged, so they need this separate PR to reach `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)