### PR TITLE
chore: release 0.14.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,7 +572,7 @@ checksum = "382ce8820a5bb815055d3553a610e8cb542b2d767bbacea99038afda96cd760d"
 
 [[package]]
 name = "cshell"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cshell"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 rust-version = "1.88.0"
 authors = ["TxPipe <hello@txpipe.io>"]


### PR DESCRIPTION
Patch release carrying the `tx3-sdk 0.14.0` adoption (#53) — `cshell` / `trix invoke` can now pass arguments of aggregate types (record/list/tuple/map) via the SDK's `TaggedArg` encoder — plus the invoke-path test (#54) and the clippy cleanup (#55).

No CLI/API change, so a patch bump.

Merging lands `0.14.2` on `main`; the `v0.14.2` tag (pushed after merge) triggers the cargo-dist release workflow. `manifest-beta.json` then pins `cshell ^0.14.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)